### PR TITLE
Remove redundant short description

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,14 +8,6 @@ body:
       value: |
         💙 Thank you for reporting this issue! Please fill out the following information.
 
-  - type: input
-    id: summary
-    attributes:
-      label: Short description
-      placeholder: Describe the issue in a few words.
-    validations:
-      required: true
-
   - type: textarea
     id: details
     attributes:


### PR DESCRIPTION
Is a short description needed when an issue already has a title? The field feels redundant, as most GitHub issues use the same text for both.